### PR TITLE
Replace deprecated actions/upload-artifact@v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           7z a au_temp.zip $Env:TEMP\chocolatey\au\*
       - name: upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: au_temp
           path: au_temp.zip


### PR DESCRIPTION
Fix broken CI because of deprecated actions/upload-artifact@v3 with current v4 version